### PR TITLE
sendmmsg() on linux

### DIFF
--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -289,6 +289,7 @@ typedef struct {
   uv__io_t io_watcher;                                                        \
   void* write_queue[2];                                                       \
   void* write_completed_queue[2];                                             \
+  int use_sendmmsg;                                                           \
 
 #define UV_PIPE_PRIVATE_FIELDS                                                \
   const char* pipe_fname; /* strdup'ed */

--- a/include/uv.h
+++ b/include/uv.h
@@ -563,7 +563,14 @@ enum uv_udp_flags {
    * (provided they all set the flag) but only the last one to bind will receive
    * any traffic, in effect "stealing" the port from the previous listener.
    */
-  UV_UDP_REUSEADDR = 4
+  UV_UDP_REUSEADDR = 4,
+  /*
+   * Indicates that this socket should use sendmmsg() to process
+   * multiple messages at once.  Only available on linux.  It's 512
+   * because the flags you pass to uv_udp_init_ex hold the address
+   * family in the lower eight bits.
+   */
+  UV_UDP_DISCORD_USE_SENDMMSG = 512
 };
 
 typedef void (*uv_udp_send_cb)(uv_udp_send_t* req, int status);

--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -36,6 +36,9 @@
 # define IPV6_DROP_MEMBERSHIP IPV6_LEAVE_GROUP
 #endif
 
+#define DISCORD_USE_SENDMMSG
+#define DISCORD_SENDMMSG_BATCHSIZE 64
+
 
 static void uv__udp_run_completed(uv_udp_t* handle);
 static void uv__udp_io(uv_loop_t* loop, uv__io_t* w, unsigned int revents);
@@ -210,6 +213,53 @@ static void uv__udp_recvmsg(uv_udp_t* handle) {
 
 
 static void uv__udp_sendmsg(uv_udp_t* handle) {
+#if defined(DISCORD_USE_SENDMMSG)
+  QUEUE* node;
+  struct msghdr* hdr;
+  struct mmsghdr hdrs[DISCORD_SENDMMSG_BATCHSIZE];
+  uv_udp_send_t* reqs[DISCORD_SENDMMSG_BATCHSIZE];
+  ssize_t send_cnt;
+  ssize_t send_res;
+  ssize_t i;
+
+  do {
+    send_cnt = 0;
+
+    QUEUE_FOREACH(node, &handle->write_queue) {
+      assert(node != NULL);
+
+      reqs[send_cnt] = QUEUE_DATA(node, uv_udp_send_t, queue);
+      assert(reqs[send_cnt] != NULL);
+
+      memset(&hdrs[send_cnt], 0, sizeof hdrs[send_cnt]);
+      hdr = &hdrs[send_cnt].msg_hdr;
+      hdr->msg_name = &reqs[send_cnt]->addr;
+      hdr->msg_namelen = (reqs[send_cnt]->addr.ss_family == AF_INET6 ?
+        sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in));
+      hdr->msg_iov = (struct iovec*) reqs[send_cnt]->bufs;
+      hdr->msg_iovlen = reqs[send_cnt]->nbufs;
+
+      if (++send_cnt == DISCORD_SENDMMSG_BATCHSIZE) {
+        break;
+      }
+    }
+
+    do {
+      send_res = sendmmsg(handle->io_watcher.fd, hdrs, send_cnt, 0);
+    } while (send_res == -1 && errno == EINTR);
+
+    if (send_res == -1 && (errno == EAGAIN || errno == EWOULDBLOCK))
+      break;
+
+    for (i = 0; i < send_cnt; ++i) {
+      reqs[i]->status = (send_res == -1 ? -errno : (ssize_t)hdrs[i].msg_len);
+
+      QUEUE_REMOVE(&reqs[i]->queue);
+      QUEUE_INSERT_TAIL(&handle->write_completed_queue, &reqs[i]->queue);
+      uv__io_feed(handle->loop, &handle->io_watcher);
+    }
+  } while (!QUEUE_EMPTY(&handle->write_queue));
+#else
   uv_udp_send_t* req;
   QUEUE* q;
   struct msghdr h;
@@ -247,6 +297,7 @@ static void uv__udp_sendmsg(uv_udp_t* handle) {
     QUEUE_INSERT_TAIL(&handle->write_completed_queue, &req->queue);
     uv__io_feed(handle->loop, &handle->io_watcher);
   }
+#endif
 }
 
 
@@ -385,7 +436,9 @@ int uv__udp_send(uv_udp_send_t* req,
                  unsigned int addrlen,
                  uv_udp_send_cb send_cb) {
   int err;
+#if !defined(DISCORD_USE_SENDMMSG)
   int empty_queue;
+#endif
 
   assert(nbufs > 0);
 
@@ -393,11 +446,13 @@ int uv__udp_send(uv_udp_send_t* req,
   if (err)
     return err;
 
+#if !defined(DISCORD_USE_SENDMMSG)
   /* It's legal for send_queue_count > 0 even when the write_queue is empty;
    * it means there are error-state requests in the write_completed_queue that
    * will touch up send_queue_size/count later.
    */
   empty_queue = (handle->send_queue_count == 0);
+#endif
 
   uv__req_init(handle->loop, req, UV_UDP_SEND);
   assert(addrlen <= sizeof(req->addr));
@@ -419,11 +474,15 @@ int uv__udp_send(uv_udp_send_t* req,
   QUEUE_INSERT_TAIL(&handle->write_queue, &req->queue);
   uv__handle_start(handle);
 
+#if defined(DISCORD_USE_SENDMMSG)
+  uv__io_start(handle->loop, &handle->io_watcher, UV__POLLOUT);
+#else
   if (empty_queue && !(handle->flags & UV_UDP_PROCESSING)) {
     uv__udp_sendmsg(handle);
   } else {
     uv__io_start(handle->loop, &handle->io_watcher, UV__POLLOUT);
   }
+#endif
 
   return 0;
 }


### PR DESCRIPTION
pickin up the work from andy.  this is a little weirdly shaped so suggestions welcome.

The intent is, if you compile with `-DDISCORD_ENABLE_SENDMMSG` then the sendmmsg() code will be compiled (so we omit that define on non-linux).  However, the `use_sendmmsg` field on `uv_udp_t` is present on any *nix, and the `UV_UDP_DISCORD_USE_SENDMMSG` flag is present on every platform.

To actually use `sendmmsg` on a given `uv_udp_t` you call `uv_udp_init_ex` with the `UV_UDP_DISCORD_USE_SENDMMSG` flag.

If the flag is weird I could keep the field and just add a post-init function that turns on `use_sendmmsg` (or we could just write to it ourselves).  Lmk whatchu thinks